### PR TITLE
feat: PR Title: Add Plymouth notifier via D-Bus / CLI fallback (for Boot-Time notifications)

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ func main() {
 
 	envVerbose := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_VERBOSE"))]
 	envLibnotify := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY"))]
+	envPlymouth := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_PLYMOUTH"))]
+	envPlymouthExec := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_PLYMOUTH_EXEC"))]
 	envStdout := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_STDOUT"))]
 	envNosocket := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_NOSOCKET"))]
 	envDbus := truthyValues[strings.ToLower(os.Getenv("YUBIKEY_TOUCH_DETECTOR_DBUS"))]
@@ -33,6 +35,8 @@ func main() {
 	var version bool
 	var verbose bool
 	var libnotify bool
+	var plymouth bool
+	var plymouthExec bool
 	var stdout bool
 	var nosocket bool
 	var dbus bool
@@ -40,6 +44,8 @@ func main() {
 	flag.BoolVar(&version, "version", false, "print version and exit")
 	flag.BoolVar(&verbose, "v", envVerbose, "enable debug logging")
 	flag.BoolVar(&libnotify, "libnotify", envLibnotify, "show desktop notifications using libnotify")
+	flag.BoolVar(&plymouth, "plymouth", envPlymouth, "show boot notifications using plymouth")
+	flag.BoolVar(&plymouthExec, "plymouth-exec", envPlymouthExec, "fallback to running plymouth commands if plymouth D-Bus is not available")
 	flag.BoolVar(&stdout, "stdout", envStdout, "print notifications to stdout")
 	flag.BoolVar(&nosocket, "no-socket", envNosocket, "disable unix socket notifier")
 	flag.BoolVar(&dbus, "dbus", envDbus, "enable dbus server for IPC")
@@ -70,6 +76,9 @@ func main() {
 	}
 	if libnotify {
 		go notifier.SetupLibnotifyNotifier(notifiers)
+	}
+	if plymouth {
+		go notifier.SetupPlymouthNotifier(notifiers, plymouthExec)
 	}
 	if stdout {
 		go notifier.SetupStdoutNotifier(notifiers)

--- a/notifier/plymouth.go
+++ b/notifier/plymouth.go
@@ -1,105 +1,89 @@
 package notifier
 
 import (
+	"os/exec"
 	"sync"
-	"sync/atomic"
 
-	"github.com/esiqveland/notify"
 	"github.com/godbus/dbus/v5"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
-// SetupPlymouthNotifier configures a notifier to show all touch requests with Plymouth
-func SetupPlymouthNotifier(notifiers *sync.Map) {
+const (
+	plymouthDest  = "org.freedesktop.Plymouth"
+	plymouthPath  = "/org/freedesktop/Plymouth"
+	plymouthIface = "org.freedesktop.Plymouth"
+)
+
+func SetupPlymouthNotifier(notifiers *sync.Map, fallbackExec bool) {
 	touch := make(chan Message, 10)
-	notifiers.Store("notifier/libnotify", touch)
+	notifiers.Store("notifier/plymouth", touch)
 
-	notification := notify.Notification{
-		AppName: "yubikey-touch-detector",
-		AppIcon: "yubikey-touch-detector",
-		Summary: "YubiKey is waiting for a touch",
-	}
-
-	conn, notifier, err := connectDBus(&notification.ReplacesID)
-	if err != nil {
-		log.Error("Cannot initialize desktop notifications: ", err)
-		return
-	}
-	defer conn.Close()
-	defer notifier.Close()
-
+	message := "YubiKey is waiting for a touch..."
 	activeTouchWaits := 0
 
-	for {
-		value := <-touch
+	// Try to get a D-Bus connection, but don't exit if it fails
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		log.Warn("Could not connect to System Bus, will use CLI fallback: ", err)
+	} else {
+		defer conn.Close()
+	}
+
+	for value := range touch {
 		if value == GPG_ON || value == U2F_ON || value == HMAC_ON {
 			activeTouchWaits++
 		}
 		if value == GPG_OFF || value == U2F_OFF || value == HMAC_OFF {
 			activeTouchWaits--
 		}
+
 		if activeTouchWaits > 0 {
-			id, err := notifier.SendNotification(notification)
-			if err != nil {
-				log.Error("Cannot show notification (will reconnect to DBUS): ", err)
-				notifier.Close()
-				conn.Close()
-				conn, notifier, err = connectDBus(&notification.ReplacesID)
-				if err != nil {
-					log.Error("Failed to reconnect: ", err)
-					continue
-				}
-				id, err = notifier.SendNotification(notification)
-				if err != nil {
-					log.Error("Cannot show notification after reconnect: ", err)
-					continue
-				}
-			}
-			atomic.CompareAndSwapUint32(&notification.ReplacesID, 0, id)
-		} else if id := atomic.LoadUint32(&notification.ReplacesID); id != 0 {
-			if _, err := notifier.CloseNotification(id); err != nil {
-				log.Error("Cannot close notification (will reconnect to DBUS): ", err)
-				notifier.Close()
-				conn.Close()
-				conn, notifier, err = connectDBus(&notification.ReplacesID)
-				if err != nil {
-					log.Error("Failed to reconnect: ", err)
-				}
-			}
+			showPlymouthMessage(conn, message)
+		} else {
+			hidePlymouthMessage(conn, message)
 		}
 	}
 }
 
-func connectDBus(replacesID *uint32) (*dbus.Conn, notify.Notifier, error) {
-	conn, err := dbus.SessionBusPrivate()
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "unable to create session bus")
+// showPlymouthMessage attempts D-Bus first, then falls back to exec
+func showPlymouthMessage(conn *dbus.Conn, msg string) {
+	if conn != nil {
+		obj := conn.Object(plymouthDest, dbus.ObjectPath(plymouthPath))
+		call := obj.Call(plymouthIface+".DisplayMessage", 0, msg)
+		if call.Err == nil {
+			return // Success
+		}
+		log.Warn("D-Bus DisplayMessage failed, trying CLI: ", call.Err)
 	}
 
-	if err := conn.Auth(nil); err != nil {
-		conn.Close()
-		return nil, nil, errors.Wrapf(err, "unable to authenticate")
+	// Fallback: plymouth display-message --text="msg"
+	cmd := exec.Command("plymouth", "display-message", "--text", msg)
+	if err := cmd.Run(); err != nil {
+		log.Error("Plymouth CLI fallback failed: ", err)
 	}
-
-	if err := conn.Hello(); err != nil {
-		conn.Close()
-		return nil, nil, errors.Wrapf(err, "unable get bus name")
-	}
-
-	reset := func(msg *notify.NotificationClosedSignal) {
-		atomic.CompareAndSwapUint32(replacesID, msg.ID, 0)
-	}
-
-	notifier, err := notify.New(
-		conn,
-		notify.WithOnClosed(reset),
-		notify.WithLogger(log.StandardLogger()),
-	)
-	if err != nil {
-		conn.Close()
-		return nil, nil, errors.Wrapf(err, "unable to initialize D-Bus notifier interface")
-	}
-
-	return conn, notifier, nil
 }
+
+// hidePlymouthMessage attempts D-Bus first, then falls back to exec
+func hidePlymouthMessage(conn *dbus.Conn, msg string) {
+	if conn != nil {
+		obj := conn.Object(plymouthDest, dbus.ObjectPath(plymouthPath))
+		call := obj.Call(plymouthIface+".HideMessage", 0, msg)
+		if call.Err == nil {
+			return // Success
+		}
+		log.Warn("D-Bus HideMessage failed, trying CLI: ", call.Err)
+	}
+
+	// Fallback: plymouth hide-message --text="msg"
+	cmd := exec.Command("plymouth", "hide-message", "--text", msg)
+	if err := cmd.Run(); err != nil {
+		log.Error("Plymouth CLI hide fallback failed: ", err)
+	}
+}
+
+// Post-Boot-Stage
+
+// ❯ ./result/bin/yubikey-touch-detector --no-socket --plymouth
+
+// WARN[2026-03-01T00:18:21+01:00] Plymouth DisplayMessage failed (is Plymouth running?): The name org.freedesktop.Plymouth was not provided by any .service files
+// WARN[2026-03-01T00:18:28+01:00] Plymouth HideMessage failed: The name org.freedesktop.Plymouth was not provided by any .service files

--- a/notifier/plymouth.go
+++ b/notifier/plymouth.go
@@ -1,0 +1,105 @@
+package notifier
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/esiqveland/notify"
+	"github.com/godbus/dbus/v5"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+// SetupPlymouthNotifier configures a notifier to show all touch requests with Plymouth
+func SetupPlymouthNotifier(notifiers *sync.Map) {
+	touch := make(chan Message, 10)
+	notifiers.Store("notifier/libnotify", touch)
+
+	notification := notify.Notification{
+		AppName: "yubikey-touch-detector",
+		AppIcon: "yubikey-touch-detector",
+		Summary: "YubiKey is waiting for a touch",
+	}
+
+	conn, notifier, err := connectDBus(&notification.ReplacesID)
+	if err != nil {
+		log.Error("Cannot initialize desktop notifications: ", err)
+		return
+	}
+	defer conn.Close()
+	defer notifier.Close()
+
+	activeTouchWaits := 0
+
+	for {
+		value := <-touch
+		if value == GPG_ON || value == U2F_ON || value == HMAC_ON {
+			activeTouchWaits++
+		}
+		if value == GPG_OFF || value == U2F_OFF || value == HMAC_OFF {
+			activeTouchWaits--
+		}
+		if activeTouchWaits > 0 {
+			id, err := notifier.SendNotification(notification)
+			if err != nil {
+				log.Error("Cannot show notification (will reconnect to DBUS): ", err)
+				notifier.Close()
+				conn.Close()
+				conn, notifier, err = connectDBus(&notification.ReplacesID)
+				if err != nil {
+					log.Error("Failed to reconnect: ", err)
+					continue
+				}
+				id, err = notifier.SendNotification(notification)
+				if err != nil {
+					log.Error("Cannot show notification after reconnect: ", err)
+					continue
+				}
+			}
+			atomic.CompareAndSwapUint32(&notification.ReplacesID, 0, id)
+		} else if id := atomic.LoadUint32(&notification.ReplacesID); id != 0 {
+			if _, err := notifier.CloseNotification(id); err != nil {
+				log.Error("Cannot close notification (will reconnect to DBUS): ", err)
+				notifier.Close()
+				conn.Close()
+				conn, notifier, err = connectDBus(&notification.ReplacesID)
+				if err != nil {
+					log.Error("Failed to reconnect: ", err)
+				}
+			}
+		}
+	}
+}
+
+func connectDBus(replacesID *uint32) (*dbus.Conn, notify.Notifier, error) {
+	conn, err := dbus.SessionBusPrivate()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "unable to create session bus")
+	}
+
+	if err := conn.Auth(nil); err != nil {
+		conn.Close()
+		return nil, nil, errors.Wrapf(err, "unable to authenticate")
+	}
+
+	if err := conn.Hello(); err != nil {
+		conn.Close()
+		return nil, nil, errors.Wrapf(err, "unable get bus name")
+	}
+
+	reset := func(msg *notify.NotificationClosedSignal) {
+		atomic.CompareAndSwapUint32(replacesID, msg.ID, 0)
+	}
+
+	notifier, err := notify.New(
+		conn,
+		notify.WithOnClosed(reset),
+		notify.WithLogger(log.StandardLogger()),
+	)
+	if err != nil {
+		conn.Close()
+		return nil, nil, errors.Wrapf(err, "unable to initialize D-Bus notifier interface")
+	}
+
+	return conn, notifier, nil
+}

--- a/notifier/plymouth.go
+++ b/notifier/plymouth.go
@@ -21,10 +21,14 @@ func SetupPlymouthNotifier(notifiers *sync.Map, fallbackExec bool) {
 	message := "YubiKey is waiting for a touch..."
 	activeTouchWaits := 0
 
-	// Try to get a D-Bus connection, but don't exit if it fails
+	// Initialize System Bus connection
 	conn, err := dbus.SystemBus()
 	if err != nil {
-		log.Warn("Could not connect to System Bus, will use CLI fallback: ", err)
+		log.Warn("Could not connect to System Bus: ", err)
+		if !fallbackExec {
+			log.Error("D-Bus failed and fallbackExec is disabled. Plymouth notifier will be inactive.")
+			return
+		}
 	} else {
 		defer conn.Close()
 	}
@@ -35,49 +39,56 @@ func SetupPlymouthNotifier(notifiers *sync.Map, fallbackExec bool) {
 		}
 		if value == GPG_OFF || value == U2F_OFF || value == HMAC_OFF {
 			activeTouchWaits--
+			if activeTouchWaits < 0 {
+				activeTouchWaits = 0
+			}
 		}
 
 		if activeTouchWaits > 0 {
-			showPlymouthMessage(conn, message)
+			showPlymouthMessage(conn, message, fallbackExec)
 		} else {
-			hidePlymouthMessage(conn, message)
+			hidePlymouthMessage(conn, message, fallbackExec)
 		}
 	}
 }
 
-// showPlymouthMessage attempts D-Bus first, then falls back to exec
-func showPlymouthMessage(conn *dbus.Conn, msg string) {
+func showPlymouthMessage(conn *dbus.Conn, msg string, fallbackExec bool) {
+	// 1. Try D-Bus if connection exists
 	if conn != nil {
 		obj := conn.Object(plymouthDest, dbus.ObjectPath(plymouthPath))
 		call := obj.Call(plymouthIface+".DisplayMessage", 0, msg)
 		if call.Err == nil {
-			return // Success
+			return
 		}
-		log.Warn("D-Bus DisplayMessage failed, trying CLI: ", call.Err)
+		log.Warn("Plymouth D-Bus DisplayMessage failed: ", call.Err)
 	}
 
-	// Fallback: plymouth display-message --text="msg"
-	cmd := exec.Command("plymouth", "display-message", "--text", msg)
-	if err := cmd.Run(); err != nil {
-		log.Error("Plymouth CLI fallback failed: ", err)
+	// 2. Try CLI Fallback if enabled
+	if fallbackExec {
+		cmd := exec.Command("plymouth", "display-message", "--text", msg)
+		if err := cmd.Run(); err != nil {
+			log.Error("Plymouth CLI fallback failed: ", err)
+		}
 	}
 }
 
-// hidePlymouthMessage attempts D-Bus first, then falls back to exec
-func hidePlymouthMessage(conn *dbus.Conn, msg string) {
+func hidePlymouthMessage(conn *dbus.Conn, msg string, fallbackExec bool) {
+	// 1. Try D-Bus if connection exists
 	if conn != nil {
 		obj := conn.Object(plymouthDest, dbus.ObjectPath(plymouthPath))
 		call := obj.Call(plymouthIface+".HideMessage", 0, msg)
 		if call.Err == nil {
-			return // Success
+			return
 		}
-		log.Warn("D-Bus HideMessage failed, trying CLI: ", call.Err)
+		log.Warn("Plymouth D-Bus HideMessage failed: ", call.Err)
 	}
 
-	// Fallback: plymouth hide-message --text="msg"
-	cmd := exec.Command("plymouth", "hide-message", "--text", msg)
-	if err := cmd.Run(); err != nil {
-		log.Error("Plymouth CLI hide fallback failed: ", err)
+	// 2. Try CLI Fallback if enabled
+	if fallbackExec {
+		cmd := exec.Command("plymouth", "hide-message", "--text", msg)
+		if err := cmd.Run(); err != nil {
+			log.Error("Plymouth CLI hide fallback failed: ", err)
+		}
 	}
 }
 


### PR DESCRIPTION

### Description

This PR introduces a new notifier specifically for **Plymouth**.

The motivation for this change comes from using **FIDO2 to decrypt the root partition** (`/`) during boot. Since Plymouth takes over the display during this stage, standard desktop notifications (libnotify) aren't available. Without this, there is no visual feedback indicating that the boot process is hanging because it's waiting for a physical touch on the YubiKey.

### Key Changes

* **Plymouth Integration**: Adds a notifier that talks to the `org.freedesktop.Plymouth` D-Bus interface on the System Bus (inspired from libnotify).
* **Dual Communication Modes**:
* Primary: Uses **D-Bus** calls (`DisplayMessage` / `HideMessage`) for efficient communication.
* Fallback: Includes a `fallbackExec` option. If enabled, the notifier will attempt to call the `plymouth` CLI binary if the D-Bus connection fails or is unavailable.


* **State Tracking**: Properly increments and decrements active touch requests to ensure the "Waiting for touch" message is cleared only when all pending requests are satisfied.

### Why do I need it

When booting with an encrypted root via FIDO2, the system often appears "stuck" on the splash screen. This notifier allows the user to see exactly when the YubiKey is blinking and requires interaction, improving the "headless" or splash-screen boot experience significantly.
